### PR TITLE
Add -buildvcs=false to make the binary slightly smaller

### DIFF
--- a/io.github.jacalz.rymdport.yml
+++ b/io.github.jacalz.rymdport.yml
@@ -36,7 +36,7 @@ modules:
     - name: rymdport
       buildsystem: simple
       build-commands:
-        - $GOROOT/bin/go build -trimpath -ldflags="-s -w" -o rymdport
+        - $GOROOT/bin/go build -trimpath -buildvcs=false -ldflags="-s -w" -o rymdport
         - install -Dm00755 rymdport $FLATPAK_DEST/bin/rymdport
         - install -Dm00644 internal/assets/icon/icon-512.png $FLATPAK_DEST/share/icons/hicolor/512x512/apps/$FLATPAK_ID.png
         - install -Dm00644 internal/assets/svg/icon.svg $FLATPAK_DEST/share/icons/hicolor/scalable/apps/$FLATPAK_ID.png


### PR DESCRIPTION
## Description

This makes sure that we strip the version control system metadata from the build and make it a bit more reproducible.

## Checklist

- [x] The changes can be built and tested locally without issues.
