### PR TITLE
Support open in rymdport by giving read only home

### DIFF
--- a/io.github.jacalz.rymdport.yml
+++ b/io.github.jacalz.rymdport.yml
@@ -20,12 +20,8 @@ finish-args:
     - --talk-name=org.freedesktop.Notifications
 
     # Support only the most common directories.
-    - --filesystem=xdg-desktop
-    - --filesystem=xdg-documents
+    - --filesystem=home:ro
     - --filesystem=xdg-download
-    - --filesystem=xdg-music
-    - --filesystem=xdg-pictures
-    - --filesystem=xdg-videos
 
 build-options:
   env:


### PR DESCRIPTION
## Description

To fully support the "Open with Rymdport" option from the file manager, we want to give access to the home folder. Lets set home folder as readable only and downloads folder as writeable.

Fixes #19

## Checklist

- [x] The changes can be built and tested locally without issues.
