### PR TITLE
Update to v3.5.2 and fix transfer of large folders

### DIFF
--- a/io.github.jacalz.rymdport.yml
+++ b/io.github.jacalz.rymdport.yml
@@ -22,6 +22,7 @@ finish-args:
     # Support only the most common directories.
     - --filesystem=home:ro
     - --filesystem=xdg-download
+    - --filesystem=/tmp # Fix https://github.com/Jacalz/rymdport/issues/93.
 
 build-options:
   env:
@@ -47,5 +48,5 @@ modules:
         - install -Dm00644 internal/assets/svg/icon.svg $FLATPAK_DEST/share/icons/hicolor/scalable/apps/$FLATPAK_ID.png
       sources:
         - type: archive
-          url: "https://github.com/Jacalz/rymdport/releases/download/v3.5.1/rymdport-v3.5.1-vendored.tar.xz"
-          sha512: fa0cf1ed6931834b31006f8cc143f6fcd7ed3d77435992f7eff30aa92be3388051cf2e325509d08d36d369cd23bce99167405ef05658b368c96d3effff05be1c
+          url: "https://github.com/Jacalz/rymdport/releases/download/v3.5.2/rymdport-v3.5.2-vendored.tar.xz"
+          sha512: 1660a135f24edd8b28c64c06e61da3d11a8cfc65a5ea522f8827f6cf31acb8da3431c84b0202febb6f7e08fb29b5075cdc8a6fe45a81291eedff12f632e48f8a


### PR DESCRIPTION
## Description

This updates Rymdport to the recently released version and includes a fix for large folders being limited by device memory.

Fixes https://github.com/Jacalz/rymdport/issues/93

## Checklist

- [x] The changes can be built and tested locally without issues.
