### PR TITLE
Update to v3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Building the package locally requires `flatpak-builder` to be installed. Install
 
 Assuming that flathub already is added as a remote, the required SDKs have to be downloaded:
 ```
-flatpak install flathub org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08 org.freedesktop.Sdk.Extension.golang//23.08
+flatpak install flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 org.freedesktop.Sdk.Extension.golang//24.08
 ```
 
 The next step is to build and install the package:

--- a/io.github.jacalz.rymdport.yml
+++ b/io.github.jacalz.rymdport.yml
@@ -45,7 +45,7 @@ modules:
         - install -Dm00644 internal/assets/icons/icon-32.png $FLATPAK_DEST/share/icons/hicolor/32x32/apps/$FLATPAK_ID.png
         - install -Dm00644 internal/assets/icons/icon-24.png $FLATPAK_DEST/share/icons/hicolor/24x24/apps/$FLATPAK_ID.png
         - install -Dm00644 internal/assets/icons/icon-16.png $FLATPAK_DEST/share/icons/hicolor/16x16/apps/$FLATPAK_ID.png
-        - install -Dm00644 internal/assets/svg/icon.svg $FLATPAK_DEST/share/icons/hicolor/scalable/apps/$FLATPAK_ID.png
+        - install -Dm00644 internal/assets/svg/icon.svg $FLATPAK_DEST/share/icons/hicolor/scalable/apps/$FLATPAK_ID.svg
       sources:
         - type: archive
           url: "https://github.com/Jacalz/rymdport/releases/download/v3.7.0/rymdport-v3.7.0-vendored.tar.xz"

--- a/io.github.jacalz.rymdport.yml
+++ b/io.github.jacalz.rymdport.yml
@@ -1,6 +1,6 @@
 app-id: io.github.jacalz.rymdport
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
     - org.freedesktop.Sdk.Extension.golang
@@ -48,5 +48,5 @@ modules:
         - install -Dm00644 internal/assets/svg/icon.svg $FLATPAK_DEST/share/icons/hicolor/scalable/apps/$FLATPAK_ID.png
       sources:
         - type: archive
-          url: "https://github.com/Jacalz/rymdport/releases/download/v3.6.0/rymdport-v3.6.0-vendored.tar.xz"
-          sha512: fd72024fa83c217317ff5dcf37203f43df0189b697b80e76d299527ed41c52017993c96bb58dbc712752ebe1103fd891ad5e601e688b08fa42723905c890e09a
+          url: "https://github.com/Jacalz/rymdport/releases/download/v3.7.0/rymdport-v3.7.0-vendored.tar.xz"
+          sha512: 8cd7c0a3b93f0f8271561db323312fededfd9d721c6f97c54947d589fc2a050f21251d2d4f196127366c26af75f20eb4324a01b51a13d7ec81385a8857f2ee64


### PR DESCRIPTION
## Description

This updates to latest Rymdport release and makes sure we are using base image 24.08 :)

## Checklist

- [x] The changes can be built and tested locally without issues.
