### PR TITLE
Make binary much smaller using compile options

### DIFF
--- a/io.github.jacalz.rymdport.yml
+++ b/io.github.jacalz.rymdport.yml
@@ -33,7 +33,7 @@ modules:
     - name: rymdport
       buildsystem: simple
       build-commands:
-        - $GOROOT/bin/go build -trimpath -buildvcs=false -ldflags="-s -w" -o rymdport
+        - $GOROOT/bin/go build -tags="no_emoji,no_metadata" -trimpath -buildvcs=false -ldflags="-s -w" -o rymdport
         - install -Dm00755 rymdport $FLATPAK_DEST/bin/rymdport
         - install -Dm00644 internal/assets/unix/$FLATPAK_ID.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop
         - install -Dm00644 internal/assets/unix/$FLATPAK_ID.appdata.xml $FLATPAK_DEST/share/appdata/$FLATPAK_ID.appdata.xml


### PR DESCRIPTION
## Description

Stop bundling emoji font and disable runtime metadata lookup.

## Checklist

- [x] The changes can be built and tested locally without issues.
